### PR TITLE
Change mount target name

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -16,5 +16,5 @@ slurm_partitions:
     nodelist: ALL
     default: YES
 
-filesystem_target_address: fileserverad1
+filesystem_target_address: fileserver
 filesystem_mount_point: /shared

--- a/site.yml
+++ b/site.yml
@@ -27,8 +27,8 @@
   hosts: all
   tags: common
   roles:
-    - filesystem
     - dhcp
+    - filesystem
     - ssh
     - epel
     - security-updates


### PR DESCRIPTION
There's only one mount target now (ACRC/oci-cluster-terraform#4) so just mount it by name.