### PR TITLE
Add network interface monitoring to telegraf configuration

### DIFF
--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -19,6 +19,15 @@
     state: started
     enabled: yes
 
+- name: enable network monitoring in telegraf
+  ini_file:
+    path: /etc/telegraf/telegraf.conf
+    section: "[inputs.net]"
+    option: interfaces
+    value: '["*"]'
+    state: present
+  notify: restart telegraf
+
 - name: install influxdb package
   yum:
     name:


### PR DESCRIPTION
Using the ansible ini_file module I wasn't able to get it to uncomment
the section just by asking it to be present. Explicitly specifying an
option and a value causes it to be written out. Since we don't know
a priori what the enames of the interfaces will be we use "*" here.
This will also include the loopback lo0, but that will liekly be in
the noise compared to the others.

Fixes #4