### PR TITLE
Reorder handlers to restart slurmctld after slurmdbd

### DIFF
--- a/roles/slurm/handlers/main.yml
+++ b/roles/slurm/handlers/main.yml
@@ -1,13 +1,18 @@
 ---
-- name: restart slurmctld
+- name: restart firewalld
   service:
-    name: slurmctld
+    name: firewalld
     state: restarted
-  when: "'management' in group_names"
 
 - name: restart slurmdbd
   service:
     name: slurmdbd
+    state: restarted
+  when: "'management' in group_names"
+
+- name: restart slurmctld
+  service:
+    name: slurmctld
     state: restarted
   when: "'management' in group_names"
 
@@ -16,8 +21,3 @@
     name: slurmd
     state: restarted
   when: "'management' not in group_names"
-
-- name: restart firewalld
-  service:
-    name: firewalld
-    state: restarted


### PR DESCRIPTION
This makes sure that `slurmctld` is restarted after `slurmdbd`. It seems if `slurmdbd` hasn't been restarted yet after the configuration file is created then when `slurmctld` tries to connect to it, it fails. On a live system, this can be resolved with a `systemctl restart slurmctld` but we need to make sure it works on first cluster creation.

Fixes #10