### PR TITLE
Remove call to scontrol from startnode (fixes #14)

### DIFF
--- a/roles/slurm/templates/startnode.j2
+++ b/roles/slurm/templates/startnode.j2
@@ -14,5 +14,4 @@ do
   else
     echo "$(date):   Failed to start ${host}" &>> ${LOGFILE}
   fi
-  scontrol update nodename=${host} nodehostname=${host} state=Resume
 done


### PR DESCRIPTION
If the `scontrol` command returns with non-zero value, the `set -e` takes effect and the script breaks out of the loop.

As it happens the `scontrol` command is not needed in this situation