### PR TITLE
Ensure OCI doesn't update /etc/resolv.conf (fixes #33)

### DIFF
--- a/roles/dhcp/tasks/main.yml
+++ b/roles/dhcp/tasks/main.yml
@@ -18,3 +18,9 @@
       subnetad1.clustervcn.oraclevcn.com
       subnetad2.clustervcn.oraclevcn.com
       subnetad3.clustervcn.oraclevcn.com
+
+- name: ensure OCI doesn't update /etc/resolv.conf
+  lineinfile:
+    path: /etc/oci-hostname.conf
+    regexp: '^PRESERVE_HOSTINFO'
+    line: 'PRESERVE_HOSTINFO=2'


### PR DESCRIPTION
The exit hook /etc/dhcp/exit-hooks.d/dhclient-exit-hook-set-hostname.sh adds a
new search line to /etc/resolve.conf every time the lease is renewed. This
upsets the name resolution. This patch flips the flag to prevent this.