### PR TITLE
Async startnode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.6"
   - "3.7"
 
-install: pip install oci pytest-mock pyyaml ansible-lint mypy requests_mock
+install: pip install oci pytest-mock pytest-asyncio pyyaml ansible-lint mypy requests_mock
 
 script:
   - pytest

--- a/roles/slurm/files/citc_oci.py
+++ b/roles/slurm/files/citc_oci.py
@@ -107,7 +107,7 @@ async def start_node(oci_config, log, host: str, nodespace: Dict[str, str], ssh_
 
     loop = asyncio.get_event_loop()
     try:
-        instance_result = await loop.run_in_executor(None, oci.core.ComputeClient(oci_config, retry_stategy=oci.retry.DEFAULT_RETRY_STRATEGY).launch_instance, instance_details)
+        instance_result = await loop.run_in_executor(None, oci.core.ComputeClient(oci_config, retry_strategy=oci.retry.DEFAULT_RETRY_STRATEGY).launch_instance, instance_details)
         instance = instance_result.data
     except oci.exceptions.ServiceError as e:
         log.error(f"{host}:  problem launching instance: {e}")

--- a/roles/slurm/files/citc_oci.py
+++ b/roles/slurm/files/citc_oci.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import re
 import subprocess
@@ -93,7 +94,7 @@ async def start_node(oci_config, log, host: str, nodespace: Dict[str, str], ssh_
 
     while get_node_state(oci_config, log, nodespace["compartment_id"], host) == "TERMINATING":
         log.info(f"{host}:  host is currently terminating. Waiting...")
-        time.sleep(5)
+        await asyncio.sleep(5)
 
     node_state = get_node_state(oci_config, log, nodespace["compartment_id"], host)
     if node_state != "TERMINATED":
@@ -114,7 +115,7 @@ async def start_node(oci_config, log, host: str, nodespace: Dict[str, str], ssh_
         node_id = instance.id
         while not oci.core.ComputeClient(oci_config).list_vnic_attachments(instance_details.compartment_id, instance_id=node_id).data:
             log.info(f"{host}:  No VNIC attachment yet. Waiting...")
-            time.sleep(5)
+            await asyncio.sleep(5)
 
         vnic_id = oci.core.ComputeClient(oci_config).list_vnic_attachments(instance_details.compartment_id, instance_id=node_id).data[0].vnic_id
         private_ip = oci.core.VirtualNetworkClient(oci_config).get_vnic(vnic_id).data.private_ip

--- a/roles/slurm/files/citc_oci.py
+++ b/roles/slurm/files/citc_oci.py
@@ -88,7 +88,7 @@ def get_ip(hostname: str) -> Tuple[Optional[str], Optional[str], Optional[str]]:
     return ip, dns_ip, slurm_ip
 
 
-def start_node(oci_config, log, host: str, nodespace: Dict[str, str], ssh_keys: str) -> None:
+async def start_node(oci_config, log, host: str, nodespace: Dict[str, str], ssh_keys: str) -> None:
     log.info(f"{host}: Starting")
 
     while get_node_state(oci_config, log, nodespace["compartment_id"], host) == "TERMINATING":

--- a/roles/slurm/files/citc_oci.py
+++ b/roles/slurm/files/citc_oci.py
@@ -39,7 +39,7 @@ def get_node_state(oci_config, log, compartment_id: str, hostname: str) -> str:
     if not still_exist:
         return "TERMINATED"
     if len(still_exist) > 1:
-        log.error(f"{host}: Multiple matches found for {hostname}")
+        log.error(f"{hostname}: Multiple matches found for {hostname}")
     return still_exist[0].lifecycle_state
 
 

--- a/roles/slurm/files/citc_oci.py
+++ b/roles/slurm/files/citc_oci.py
@@ -105,8 +105,10 @@ async def start_node(oci_config, log, host: str, nodespace: Dict[str, str], ssh_
 
     instance_details = create_node_config(oci_config, host, ip, nodespace, ssh_keys)
 
+    loop = asyncio.get_event_loop()
     try:
-        instance = oci.core.ComputeClient(oci_config).launch_instance(instance_details).data
+        instance_result = await loop.run_in_executor(None, oci.core.ComputeClient(oci_config).launch_instance, instance_details)
+        instance = instance_result.data
     except oci.exceptions.ServiceError as e:
         log.error(f"{host}:  problem launching instance: {e}")
         return

--- a/roles/slurm/files/citc_oci.py
+++ b/roles/slurm/files/citc_oci.py
@@ -39,7 +39,7 @@ def get_node_state(oci_config, log, compartment_id: str, hostname: str) -> str:
     if not still_exist:
         return "TERMINATED"
     if len(still_exist) > 1:
-        log.error(f"Multiple matches found for {hostname}")
+        log.error(f"{host}: Multiple matches found for {hostname}")
     return still_exist[0].lifecycle_state
 
 
@@ -89,15 +89,15 @@ def get_ip(hostname: str) -> Tuple[Optional[str], Optional[str], Optional[str]]:
 
 
 def start_node(oci_config, log, host: str, nodespace: Dict[str, str], ssh_keys: str) -> None:
-    log.info(f"Starting {host}")
+    log.info(f"{host}: Starting")
 
     while get_node_state(oci_config, log, nodespace["compartment_id"], host) == "TERMINATING":
-        log.info(" host is currently terminating. Waiting...")
+        log.info(f"{host}:  host is currently terminating. Waiting...")
         time.sleep(5)
 
     node_state = get_node_state(oci_config, log, nodespace["compartment_id"], host)
     if node_state != "TERMINATED":
-        log.warning(f" host is already running with state {node_state}")
+        log.warning(f"{host}:  host is already running with state {node_state}")
         return
 
     ip, _dns_ip, slurm_ip = get_ip(host)
@@ -107,22 +107,22 @@ def start_node(oci_config, log, host: str, nodespace: Dict[str, str], ssh_keys: 
     try:
         instance = oci.core.ComputeClient(oci_config).launch_instance(instance_details).data
     except oci.exceptions.ServiceError as e:
-        log.error(f" problem launching instance: {e}")
+        log.error(f"{host}:  problem launching instance: {e}")
         return
 
     if not slurm_ip:
         node_id = instance.id
         while not oci.core.ComputeClient(oci_config).list_vnic_attachments(instance_details.compartment_id, instance_id=node_id).data:
-            log.info(" No VNIC attachment yet. Waiting...")
+            log.info(f"{host}:  No VNIC attachment yet. Waiting...")
             time.sleep(5)
 
         vnic_id = oci.core.ComputeClient(oci_config).list_vnic_attachments(instance_details.compartment_id, instance_id=node_id).data[0].vnic_id
         private_ip = oci.core.VirtualNetworkClient(oci_config).get_vnic(vnic_id).data.private_ip
 
-        log.info(f"  Private IP {private_ip}")
+        log.info(f"{host}:   Private IP {private_ip}")
         subprocess.run(["scontrol", "update", f"NodeName={host}", f"NodeAddr={private_ip}"])
 
-    log.info(f" Started {host}")
+    log.info(f"{host}:  Started")
     return instance
 
 

--- a/roles/slurm/files/citc_oci.py
+++ b/roles/slurm/files/citc_oci.py
@@ -107,7 +107,7 @@ async def start_node(oci_config, log, host: str, nodespace: Dict[str, str], ssh_
 
     loop = asyncio.get_event_loop()
     try:
-        instance_result = await loop.run_in_executor(None, oci.core.ComputeClient(oci_config).launch_instance, instance_details)
+        instance_result = await loop.run_in_executor(None, oci.core.ComputeClient(oci_config, retry_stategy=oci.retry.DEFAULT_RETRY_STRATEGY).launch_instance, instance_details)
         instance = instance_result.data
     except oci.exceptions.ServiceError as e:
         log.error(f"{host}:  problem launching instance: {e}")

--- a/roles/slurm/files/startnode.py
+++ b/roles/slurm/files/startnode.py
@@ -17,12 +17,6 @@ def handle_exception(exc_type, exc_value, exc_traceback):
 
 
 def main() -> None:
-    log = logging.getLogger("startnode")
-    log.setLevel(logging.INFO)
-    handler = logging.FileHandler('/var/log/slurm/elastic.log')
-    formatter = logging.Formatter('%(asctime)s %(name)-10s %(levelname)-8s %(message)s')
-    handler.setFormatter(formatter)
-    log.addHandler(handler)
 
     oci_config = oci.config.from_file()
 
@@ -43,3 +37,9 @@ sys.excepthook = handle_exception
 
 if __name__ == "__main__":
     main()
+    log = logging.getLogger("startnode")
+    log.setLevel(logging.INFO)
+    handler = logging.FileHandler('/var/log/slurm/elastic.log')
+    formatter = logging.Formatter('%(asctime)s %(name)-10s %(levelname)-8s %(message)s')
+    handler.setFormatter(formatter)
+    log.addHandler(handler)

--- a/roles/slurm/files/test_citc_oci.py
+++ b/roles/slurm/files/test_citc_oci.py
@@ -180,7 +180,8 @@ def test_get_ip(host_good, scontrol_good, expected, mocker):
     assert citc_oci.get_ip("foo") == expected
 
 
-def test_start_node_fresh(oci_config, mocker, requests_mocker, nodespace):
+@pytest.mark.asyncio
+async def test_start_node_fresh(oci_config, mocker, requests_mocker, nodespace):
     requests_mocker.register_uri(
         "GET",
         "/20160918/instances/?compartmentId=ocid1.compartment.oc1..aaaaa&displayName=foo",
@@ -220,6 +221,6 @@ def test_start_node_fresh(oci_config, mocker, requests_mocker, nodespace):
         text=json.dumps(serialize(vnic)),
     )
 
-    instance = citc_oci.start_node(oci_config, mocker.Mock(), "foo", nodespace, "")
+    instance = await citc_oci.start_node(oci_config, mocker.Mock(), "foo", nodespace, "")
 
     assert instance.id == "ocid0..instance.foo"

--- a/roles/slurm/tasks/elastic.yml
+++ b/roles/slurm/tasks/elastic.yml
@@ -77,7 +77,7 @@
     dest: /opt/oci/lib/python3.6/site-packages/citc_oci.py
 
 - name: configure startnode script
-  template:
+  copy:
     src: startnode.py
     dest: /usr/local/bin/startnode
     mode: 0755

--- a/roles/slurm/tasks/elastic.yml
+++ b/roles/slurm/tasks/elastic.yml
@@ -90,7 +90,7 @@
 
 - name: configure update_config script
   template:
-    src: update_config.j2
+    src: update_config.py
     dest: /usr/local/bin/update_config
     mode: 0755
 

--- a/roles/slurm/tasks/elastic.yml
+++ b/roles/slurm/tasks/elastic.yml
@@ -78,7 +78,7 @@
 
 - name: configure startnode script
   template:
-    src: startnode.j2
+    src: startnode.py
     dest: /usr/local/bin/startnode
     mode: 0755
 
@@ -90,7 +90,7 @@
 
 - name: configure update_config script
   template:
-    src: update_config.py
+    src: update_config.j2
     dest: /usr/local/bin/update_config
     mode: 0755
 

--- a/roles/slurm/templates/slurm_shared.conf.j2
+++ b/roles/slurm/templates/slurm_shared.conf.j2
@@ -8,6 +8,8 @@ AccountingStorageType=accounting_storage/slurmdbd
 ResumeProgram=/usr/local/bin/startnode
 SuspendProgram=/usr/local/bin/stopnode
 SuspendTime=900
+# ResumeRate tuned for OCI rate limit in nodes/min
+ResumeRate=20
 ResumeTimeout=600
 SuspendTimeout=60
 


### PR DESCRIPTION
This ports the startnode script to use asyncio to start multiple nodes in parallel.

It creates an asyncio task for each host that's being asked to start. These tasks can then be run concurrently as long as each yields control while it's waiting for some external I/O to happen. At present it only yields on the call to `launch_instance` and while sleeping for waiting for VNICs to attach and instances to terminate.

Since this can now send all the launch requests in parallel, it will make the rate limiting issue in #29 worse. To this end, I have also applied a default retry strategy as [documented in the Python OCI docs](https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/sdk_behaviors/retries.html).

The two potential pitfalls of this retry strategy is that it has a limit of 5 retries and a max timeout of 5 minutes for for the request to go through. We'll have to test this on our large 117 node cluster again.

Fixes #29
Fixes #31