### PR TITLE
Update Grafana repo URL

### DIFF
--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -55,8 +55,8 @@
   yum_repository:
     name: grafana
     description: Grafana
-    baseurl: https://packagecloud.io/grafana/stable/el/7/$basearch
-    gpgkey: https://packagecloud.io/gpg.key https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana
+    baseurl: https://packages.grafana.com/oss/rpm
+    gpgkey: https://packages.grafana.com/gpg.key
   when: monitoring_role == "master"
 
 - name: install grafana package


### PR DESCRIPTION
It seems the official Grafana repo URL has changed which will cause installs to fail. This updates to the URL from https://grafana.com/docs/installation/rpm/.