### PR TITLE
Fix Python binary path

### DIFF
--- a/roles/slurm/tasks/elastic.yml
+++ b/roles/slurm/tasks/elastic.yml
@@ -13,7 +13,7 @@
       - oci
       - PyYAML
     virtualenv: /opt/oci
-    virtualenv_command: /bin/python36 -m venv
+    virtualenv_command: /bin/python3 -m venv
 
 - name: create oci config directory
   file:


### PR DESCRIPTION
Previously installing the `python36` package would install a symlink at `/bin/python36`. Something has changed in the packaging such that `python36` is now obsoleted by `python3-3.6...` which does not install the symlink. This PR changes the created venv so that it uses the `/bin/python3` path.

Fixes acrc/oci-cluster-terraform#40