### PR TITLE
Specify version of mpich as 3.2

### DIFF
--- a/group_vars/compute.yml
+++ b/group_vars/compute.yml
@@ -6,7 +6,7 @@ slurm_packages:
 slurm_role: compute
 
 install_packages:
-  - mpich
+  - mpich-3.2
   - openmpi3
 
 monitoring_role: client

--- a/group_vars/management.yml
+++ b/group_vars/management.yml
@@ -14,7 +14,7 @@ slurm_elastic:
 
 install_packages:
   - xorg-x11-xauth
-  - mpich-devel
+  - mpich-3.2-devel
   - openmpi-devel
   - openmpi3-devel
   - devtoolset-8


### PR DESCRIPTION
The compute nodes were installing mpich 3.0 for some reason. This makes the management nodes and compute nodes match.