### PR TITLE
Add provider-agnostic `citc` user

### DIFF
--- a/compute.yml
+++ b/compute.yml
@@ -8,6 +8,7 @@
 
 - hosts: compute
   roles:
+    - citc_user
     - filesystem
     - ssh
     #- security-updates

--- a/management.yml
+++ b/management.yml
@@ -22,6 +22,7 @@
   hosts: all
   tags: common
   roles:
+    - citc_user
     - filesystem
     - ssh
     - security-updates

--- a/roles/citc_user/tasks/main.yml
+++ b/roles/citc_user/tasks/main.yml
@@ -49,3 +49,10 @@
     group: citc
     mode: 0600
   when: '"/root/citc_authorized_keys" is exists'
+
+- name: Add citc to sudoers
+  copy:
+    content: |
+      citc ALL=(ALL) NOPASSWD:ALL
+    dest: /etc/sudoers.d/91-citc
+    validate: /usr/sbin/visudo -cf %s

--- a/roles/citc_user/tasks/main.yml
+++ b/roles/citc_user/tasks/main.yml
@@ -26,7 +26,7 @@
 - name: copy SSH public keys to citc user
   copy:
     src: /home/opc/.ssh/authorized_keys
-    dest: "{{ citc_user }}/.ssh/authorized_keys"
+    dest: "{{ citc_user.home }}/.ssh/authorized_keys"
     owner: citc
     group: citc
     mode: 0600
@@ -34,7 +34,7 @@
 - name: copy SSH public keys to citc user
   copy:
     src: /home/provisioner/.ssh/authorized_keys
-    dest: "{{ citc_user }}/.ssh/authorized_keys"
+    dest: "{{ citc_user.home }}/.ssh/authorized_keys"
     owner: citc
     group: citc
     mode: 0600
@@ -42,7 +42,7 @@
 - name: copy SSH public keys to citc user
   copy:
     src: /root/citc_authorized_keys
-    dest: "{{ citc_user }}/.ssh/authorized_keys"
+    dest: "{{ citc_user.home }}/.ssh/authorized_keys"
     owner: citc
     group: citc
     mode: 0600

--- a/roles/citc_user/tasks/main.yml
+++ b/roles/citc_user/tasks/main.yml
@@ -1,0 +1,49 @@
+---
+
+- name: Create citc group
+  group:
+    name: citc
+    gid: 1005
+
+- name: Create the citc user
+  user:
+    name: citc
+    comment: CitC Admin
+    uid: 1005
+    group: citc
+    groups:
+      - adm
+      - wheel
+      - systemd-journal
+  register: citc_user
+
+- name: Create citc user .ssh dir
+  file:
+    path: "{{ citc_user.home }}/.ssh"
+    state: directory
+    mode: 0700
+
+- name: copy SSH public keys to citc user
+  copy:
+    src: /home/opc/.ssh/authorized_keys
+    dest: "{{ citc_user }}/.ssh/authorized_keys"
+    owner: citc
+    group: citc
+    mode: 0600
+  when: '"/home/opc/.ssh/authorized_keys" is exists'
+- name: copy SSH public keys to citc user
+  copy:
+    src: /home/provisioner/.ssh/authorized_keys
+    dest: "{{ citc_user }}/.ssh/authorized_keys"
+    owner: citc
+    group: citc
+    mode: 0600
+  when: '"/home/provisioner/.ssh/authorized_keys" is exists'
+- name: copy SSH public keys to citc user
+  copy:
+    src: /root/citc_authorized_keys
+    dest: "{{ citc_user }}/.ssh/authorized_keys"
+    owner: citc
+    group: citc
+    mode: 0600
+  when: '"/root/citc_authorized_keys" is exists'

--- a/roles/citc_user/tasks/main.yml
+++ b/roles/citc_user/tasks/main.yml
@@ -21,6 +21,8 @@
   file:
     path: "{{ citc_user.home }}/.ssh"
     state: directory
+    owner: citc
+    group: citc
     mode: 0700
 
 - name: copy SSH public keys to citc user

--- a/roles/slurm/tasks/elastic.yml
+++ b/roles/slurm/tasks/elastic.yml
@@ -121,6 +121,11 @@
       chmod 600 /etc/ssh/ssh_host_*
       chmod 644 /etc/ssh/ssh_host_*.pub
 
+      # Put the admin ssh keys somewhere that can be found
+      cat > /root/citc_authorized_keys << EOF
+      {{ lookup('file', '/home/citc/.ssh/authorized_keys') }}
+      EOF
+
       yum install -y ansible git
       cat > /root/hosts <<EOF
       [compute]


### PR DESCRIPTION
This creates a `citc` user on all systems as the first things that Ansible does. It will use the same SSH keys as `opc`/`provisioner`.

Fixes acrc/citc-terraform#42