### PR TITLE
Add rsyslog (Fixes #60)

### DIFF
--- a/roles/monitoring/handlers/main.yml
+++ b/roles/monitoring/handlers/main.yml
@@ -1,5 +1,11 @@
 ---
 
+
+- name: restart rsyslog
+  service:
+    name: rsyslog
+    state: restarted
+
 - name: restart telegraf
   service:
     name: telegraf

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -21,6 +21,7 @@
     - { regexp: '#\$UDPServerRun 514',      replace: '$UDPServerRun 514'      }
     - { regexp: '#\$ModLoad imtcp',         replace: '$ModLoad imtcp'         }
     - { regexp: '#\$InputTCPServerRun 514', replace: '$InputTCPServerRun 514' }
+  notify: restart rsyslog
   when: monitoring_role == "master"
 
 - name: configure compute nodes to send syslog

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -27,7 +27,7 @@
     block: |
       $ModLoad imtcp
       $InputTCPServerRun 514
-  notify: restart telegraf
+  notify: restart rsyslog
   when: monitoring_role == "master"
 
 - name: configure compute nodes to send syslog
@@ -35,7 +35,7 @@
     path: /etc/rsyslog.conf
     regexp: '@@remote-host:514'
     line: '*.* @@mgmt:514'
-  notify: restart telegraf
+  notify: restart rsyslog
   when: monitoring_role != "master"
 
 - name: Add InfluxDB repository

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -17,10 +17,10 @@
     regexp: "{{ item.regexp }}"
     replace: "{{ item.replace }}"
   with_items:
-    - { regexp: '#$ModLoad imudp',         replace: '$ModLoad imudp'         }
-    - { regexp: '#$UDPServerRun 514',      replace: '$UDPServerRun 514'      }
-    - { regexp: '#$ModLoad imtcp',         replace: '$ModLoad imtcp'         }
-    - { regexp: '#$InputTCPServerRun 514', replace: '$InputTCPServerRun 514' }
+    - { regexp: '#\$ModLoad imudp',         replace: '$ModLoad imudp'         }
+    - { regexp: '#\$UDPServerRun 514',      replace: '$UDPServerRun 514'      }
+    - { regexp: '#\$ModLoad imtcp',         replace: '$ModLoad imtcp'         }
+    - { regexp: '#\$InputTCPServerRun 514', replace: '$InputTCPServerRun 514' }
   when: monitoring_role == "master"
 
 - name: configure compute nodes to send syslog

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -10,7 +10,7 @@
     name: rsyslog
     state: started
     enabled: yes
-  
+
 - name: configure mgmt to recieve syslog on UDP and TCP
   replace:
     path: /etc/rsyslog.conf

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -1,5 +1,43 @@
 ---
 
+- name: install rsyslog
+  yum:
+    name:
+      - rsyslog
+
+- name: enable the rsyslog service
+  service:
+    name: rsyslog
+    state: started
+    enabled: yes
+  
+- name: configure mgmt to recieve syslog on UDP
+  blockinfile:
+    path: /etc/rsyslog.conf
+    marker: "^# Provides UDP syslog reception"
+    block: |
+      $ModLoad imudp
+      $UDPServerRun 514
+  when: monitoring_role == "master"
+
+- name: configure mgmt to recieve syslog on UDP
+  blockinfile:
+    path: /etc/rsyslog.conf
+    marker: "^# Provides TCP syslog reception"
+    block: |
+      $ModLoad imtcp
+      $InputTCPServerRun 514
+  notify: restart telegraf
+  when: monitoring_role == "master"
+
+- name: configure compute nodes to send syslog
+  lineinfile:
+    path: /etc/rsyslog.conf
+    regexp: '@@remote-host:514'
+    line: '*.* @@mgmt:514'
+  notify: restart telegraf
+  when: monitoring_role != "master"
+
 - name: Add InfluxDB repository
   yum_repository:
     name: influxdb

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -11,23 +11,16 @@
     state: started
     enabled: yes
   
-- name: configure mgmt to recieve syslog on UDP
-  blockinfile:
+- name: configure mgmt to recieve syslog on UDP and TCP
+  replace:
     path: /etc/rsyslog.conf
-    marker: "^# Provides UDP syslog reception"
-    block: |
-      $ModLoad imudp
-      $UDPServerRun 514
-  when: monitoring_role == "master"
-
-- name: configure mgmt to recieve syslog on UDP
-  blockinfile:
-    path: /etc/rsyslog.conf
-    marker: "^# Provides TCP syslog reception"
-    block: |
-      $ModLoad imtcp
-      $InputTCPServerRun 514
-  notify: restart rsyslog
+    regexp: "{{ item.regexp }}"
+    replace: "{{ item.replace }}"
+  with_items:
+    - { regexp: '#$ModLoad imudp',         replace: '$ModLoad imudp'         }
+    - { regexp: '#$UDPServerRun 514',      replace: '$UDPServerRun 514'      }
+    - { regexp: '#$ModLoad imtcp',         replace: '$ModLoad imtcp'         }
+    - { regexp: '#$InputTCPServerRun 514', replace: '$InputTCPServerRun 514' }
   when: monitoring_role == "master"
 
 - name: configure compute nodes to send syslog


### PR DESCRIPTION
The yum install and enable should be no-ops as rsyslog is already installed and enabled on the OS images we have on Oracle and Google.


