### PR TITLE
Change sosreport default compression to gzip (fixes #78)

### DIFF
--- a/roles/sos/files/sos.conf
+++ b/roles/sos/files/sos.conf
@@ -1,0 +1,12 @@
+[general]
+#verbose = 3
+#verify = yes
+#batch = yes
+#log-size = 15
+compression = gzip
+
+[plugins]
+#disable = rpm, selinux, dovecot
+
+[tunables]
+#rpm.rpmva = off

--- a/roles/sos/tasks/main.yml
+++ b/roles/sos/tasks/main.yml
@@ -11,3 +11,11 @@
     owner: root
     group: root
     mode: 0644
+
+- name: update SOS config compression to gzip
+  copy:
+    src: sos.conf
+    dest: /etc/sos/conf
+    owner: root
+    group: root
+    mode: 0644


### PR DESCRIPTION
As it comes from upstream, the sosreport utility produces .xz files by default.
We invisige the most common use case will be uploading these to GitHub issues
so we need to set it to a file type GitHub will allow. This change adds a
/etc/sos.conf with the compression defaulting to gzip.