### PR TITLE
Use python-citc module to start AWS nodes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install oci pytest-mock pytest-asyncio pyyaml ansible-lint mypy requests_mock google-api-python-client google-auth boto3 "boto3-stubs[ec2,route53]"
-        python -m mypy_boto3
     - name: Test with pytest
       run: pytest
     - name: Ansible lint

--- a/roles/slurm/files/citc_aws.py
+++ b/roles/slurm/files/citc_aws.py
@@ -236,13 +236,11 @@ def terminate_instance(log, hosts, nodespace=None):
         log.info(f"Stopping {host}")
 
         try:
-            instance = citc.aws.AwsNode.from_name(client, host, nodespace)
-            instance_id = instance["InstanceId"]
-            vm_ip = instance["PrivateIpAddress"]
+            instance = citc.aws.AwsNode.from_name(host, client, nodespace)
             fqdn = f"{host}.{nodespace['dns_zone']}"
-            client.terminate_instances(InstanceIds=[instance_id])
+            client.terminate_instances(InstanceIds=[instance.id])
             r53_client = route53_client()
-            delete_dns_record(r53_client, nodespace["dns_zone_id"], fqdn, "A", vm_ip, 300)
+            delete_dns_record(r53_client, nodespace["dns_zone_id"], fqdn, "A", instance.ip, 300)
         except Exception as e:
             log.error(f" problem while stopping: {e}")
             continue

--- a/roles/slurm/files/citc_aws.py
+++ b/roles/slurm/files/citc_aws.py
@@ -5,20 +5,8 @@ import yaml
 import asyncio
 
 import boto3
+import citc.utils
 #from mypy_boto3 import ec2, route53
-
-
-def load_yaml(filename: str) -> dict:
-    with open(filename, "r") as f:
-        return yaml.safe_load(f)
-
-
-def get_nodespace(file="/etc/citc/startnode.yaml") -> Dict[str, str]:
-    """
-    Get the information about the space into which we were creating nodes
-    This will be static for all nodes in this cluster
-    """
-    return load_yaml(file)
 
 
 def get_node(client, hostname: str, cluster_id: str):  # -> ec2.Instance?
@@ -258,7 +246,7 @@ async def start_node(log, host: str, nodespace: Dict[str, str], ssh_keys: str) -
 
 def terminate_instance(log, hosts, nodespace=None):
     if not nodespace:
-        nodespace = get_nodespace()
+        nodespace = citc.utils.get_nodespace()
 
     region = nodespace["region"]
 

--- a/roles/slurm/files/startnode.py
+++ b/roles/slurm/files/startnode.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import subprocess
 import sys
+import citc.utils
 import citc_cloud
 
 
@@ -17,7 +18,7 @@ def handle_exception(exc_type, exc_value, exc_traceback):
 
 
 async def main() -> None:
-    nodespace = citc_cloud.get_nodespace()
+    nodespace = citc.utils.get_nodespace()
 
     keys_file = "/home/slurm/opc_authorized_keys"
 

--- a/roles/slurm/tasks/elastic.yml
+++ b/roles/slurm/tasks/elastic.yml
@@ -3,7 +3,7 @@
   pip:
     name:
       - PyYAML
-      - https://github.com/clusterinthecloud/python-citc/releases/download/0.3.8/citc-0.3.8-py3-none-any.whl
+      - https://github.com/clusterinthecloud/python-citc/releases/download/0.3.9/citc-0.3.9-py3-none-any.whl
     virtualenv: /opt/cloud_sdk
     virtualenv_command: "{{ python_venv }}"
   register: cloud_sdk_venv

--- a/roles/slurm/tasks/elastic.yml
+++ b/roles/slurm/tasks/elastic.yml
@@ -3,7 +3,7 @@
   pip:
     name:
       - PyYAML
-      - https://github.com/clusterinthecloud/python-citc/releases/download/0.3.5/citc-0.3.5-py3-none-any.whl
+      - https://github.com/clusterinthecloud/python-citc/releases/download/0.3.6/citc-0.3.6-py3-none-any.whl
     virtualenv: /opt/cloud_sdk
     virtualenv_command: "{{ python_venv }}"
   register: cloud_sdk_venv

--- a/roles/slurm/tasks/elastic.yml
+++ b/roles/slurm/tasks/elastic.yml
@@ -3,7 +3,7 @@
   pip:
     name:
       - PyYAML
-      - https://github.com/clusterinthecloud/python-citc/releases/download/0.3.6/citc-0.3.6-py3-none-any.whl
+      - https://github.com/clusterinthecloud/python-citc/releases/download/0.3.8/citc-0.3.8-py3-none-any.whl
     virtualenv: /opt/cloud_sdk
     virtualenv_command: "{{ python_venv }}"
   register: cloud_sdk_venv


### PR DESCRIPTION
This uses the https://github.com/milliams/python-citc module to provide more of the functionality in the AWS start/stop node scripts. Most notably is the replacement of `shapes.yaml` with an API-driven method implemented in [`get_types_info`](https://github.com/clusterinthecloud/python-citc/blob/ad7cf32b1ef664db9e326cb54532d221abf10929/citc/aws.py#L90).

This is passing the test suite but the CI is having an issue due to Ansible upgrades. I'll merge this and tackle the CI another time.