### PR TITLE
Fix for missing kill-all-nodes script

### DIFF
--- a/roles/slurm/tasks/elastic.yml
+++ b/roles/slurm/tasks/elastic.yml
@@ -68,7 +68,7 @@
 
 - name: install kill_all_nodes script
   copy:
-    src: kill_all_nodes.py
+    src: kill_all_nodes.sh
     dest: /usr/local/bin/kill_all_nodes
     mode: u=rwx,g=rwx,o=r
 


### PR DESCRIPTION
Fixes https://github.com/clusterinthecloud/support/issues/17

Use .sh not .py