### PR TITLE
Reduce idle wait time to 10 minutes

### DIFF
--- a/roles/slurm/templates/slurm_shared.conf.j2
+++ b/roles/slurm/templates/slurm_shared.conf.j2
@@ -11,7 +11,7 @@ SlurmdSyslogDebug=info
 # ELASTIC
 ResumeProgram=/usr/local/bin/startnode
 SuspendProgram=/usr/local/bin/stopnode
-SuspendTime=900
+SuspendTime=600
 # ResumeRate tuned for OCI rate limit in nodes/min
 ResumeRate=20
 ResumeTimeout=600


### PR DESCRIPTION
Nodes start much more quickly than they used to, so 10 minutes is a better compromise.