### PR TITLE
Increase packer AWS builder disk size

### DIFF
--- a/roles/packer/files/all.pkr.hcl
+++ b/roles/packer/files/all.pkr.hcl
@@ -84,6 +84,11 @@ source "amazon-ebs" "aws" {
         }
     }
     associate_public_ip_address = true
+
+    launch_block_device_mappings {
+        device_name = "/dev/sda1"
+        volume_size =  40
+    }
 }
 
 source "oracle-oci" "oracle" {


### PR DESCRIPTION
By default it seems the AWS builder has a cap at 8GB of file storage.
Quickly this becomes an issue when installing large toolchains like
CUDA. This change gives the builder a 40GB block store which is
snapshotted at the end of the build process to form the AMI.