### PR TITLE
Run packer role async

### DIFF
--- a/management.yml
+++ b/management.yml
@@ -36,16 +36,16 @@
   roles:
     - citc_user
     - ldap
-    - packer
+    - mysql
+    - python
     - filesystem
+    - slurm
+    - packer
     - ssh
     - security_updates
     - ntp
     - sssd
-    - python
     - users
-    - mysql
-    - slurm
   tasks:
     - name: copy SSH public keys to slurm account
       copy:

--- a/management.yml
+++ b/management.yml
@@ -35,12 +35,12 @@
   tags: common
   roles:
     - citc_user
+    - ldap
     - packer
     - filesystem
     - ssh
     - security_updates
     - ntp
-    - ldap
     - sssd
     - python
     - users

--- a/management.yml
+++ b/management.yml
@@ -35,6 +35,7 @@
   tags: common
   roles:
     - citc_user
+    - packer
     - filesystem
     - ssh
     - security_updates
@@ -45,7 +46,6 @@
     - users
     - mysql
     - slurm
-    - packer
   tasks:
     - name: copy SSH public keys to slurm account
       copy:

--- a/roles/finalise/tasks/main.yml
+++ b/roles/finalise/tasks/main.yml
@@ -1,5 +1,14 @@
 ---
 
+- name: Wait for packer to finish
+  async_status:
+    jid: "{{ packer_result.ansible_job_id }}"
+  register: packer_job_result
+  until: packer_job_result.finished
+  retries: 100
+  delay: 10
+  tags: packer
+
 - name: create directory for the finalised files
   file:
     path: /mnt/shared/finalised

--- a/roles/packer/tasks/main.yml
+++ b/roles/packer/tasks/main.yml
@@ -60,9 +60,10 @@
     dest: /usr/local/bin/run-packer
     mode: u=rwx,g=rx,o=rx
 
+# Ansible will not wait for this task until it gets to the `finalise` role
 - name: run packer to build first image
   command: /usr/local/bin/run-packer
   register: packer_result
-  changed_when: "packer_result.rc == 0"
-  failed_when: "packer_result.rc != 0"
+  async: 1000
+  poll: 0
   tags: packer

--- a/roles/packer/tasks/main.yml
+++ b/roles/packer/tasks/main.yml
@@ -27,6 +27,19 @@
     dest: /etc/citc/packer/all.pkr.hcl
     mode: u=rw,g=r,o=r
 
+- name: create citc config dir
+  file:
+    path: /etc/citc
+    state: directory
+    mode: 0755
+
+- name: copy startnode.yaml
+  copy:
+    src: /tmp/startnode.yaml
+    dest: /etc/citc/startnode.yaml
+    remote_src: yes
+    mode: 0744
+
 - name: load the startnode config
   include_vars:
     file: /etc/citc/startnode.yaml

--- a/roles/packer/tasks/main.yml
+++ b/roles/packer/tasks/main.yml
@@ -75,7 +75,7 @@
 
 # Ansible will not wait for this task until it gets to the `finalise` role
 - name: run packer to build first image
-  command: /usr/local/bin/run-packer
+  command: /usr/local/bin/run-packer  # noqa no-changed-when
   register: packer_result
   async: 1000
   poll: 0


### PR DESCRIPTION
Move `packer` earlier in the build process but make it run asynchronously. The result of the packer run is not checked until the `finalise` role.

It still depends on the `slurm` role for the API credential files and the `ldap` role for the CA cert. The former could be simplified in the future by moving that out of the Slurm role into a `csp_creds` role for example.