### PR TITLE
aarch64 packer instance fixes

### DIFF
--- a/roles/packer/templates/run-packer.sh.j2
+++ b/roles/packer/templates/run-packer.sh.j2
@@ -21,8 +21,8 @@ elif [[ "$1" == "aarch64" ]]; then
     /usr/local/bin/packer build \
         -var-file /etc/citc/packer/variables.pkrvars.hcl \
         -only="*.{{ ansible_local.citc.csp }}" \
-        -var 'aws_arch="arm64"' \
-        -var 'aws_instance_type="a1.medium"' \
+        -var 'aws_arch=arm64' \
+        -var 'aws_instance_type=a1.medium' \
         /etc/citc/packer/
 {% endif %}
 else

--- a/roles/packer/templates/run-packer.sh.j2
+++ b/roles/packer/templates/run-packer.sh.j2
@@ -22,7 +22,7 @@ elif [[ "$1" == "aarch64" ]]; then
         -var-file /etc/citc/packer/variables.pkrvars.hcl \
         -only="*.{{ ansible_local.citc.csp }}" \
         -var 'aws_arch=arm64' \
-        -var 'aws_instance_type=a1.medium' \
+        -var 'aws_instance_type=m6g.medium' \
         /etc/citc/packer/
 {% endif %}
 else


### PR DESCRIPTION
Hello,

I've encountered [an issue](https://github.com/clusterinthecloud/support/issues/36) with the `packer build` step from aarch64 instances. The issue seems to be with the quoting on the instance type variables.

There is a further issue that the old `a1` (Graviton 1) instances are no longer available in some regions. I've updated the build step to use the newer `m6g` (Graviton 2) shapes.

Thank you.