### PR TITLE
Don't always install cvmfs

### DIFF
--- a/roles/packer/files/all.pkr.hcl
+++ b/roles/packer/files/all.pkr.hcl
@@ -172,8 +172,4 @@ build {
     provisioner "shell" {
         script = "/home/citc/compute_image_extra.sh"
     }
-
-    provisioner "shell" {
-        script = "/home/citc/install_cvmfs_eessi.sh"
-    }
 }


### PR DESCRIPTION
A script to install cvmfs is already present in `/home/citc/install_cvmfs_eessi.sh`. In `compute_image_extra.sh`, the user is told to enable it manually if desired:

```
# to install CernVM-FS and configure access to EESSI, uncomment the line below:
# /home/citc/install_cvmfs_eessi.sh
```

...but this script is automatically called from `/etc/citc/packer/all.pkr.hcl`.

This installation step takes significant time, so it would be better to only enable it when the user asks for it, as per the comment in the image script. This PR removes the packer step that automatically install cvmfs.