### PR TITLE
Slurm: upgrade from 20.02 to 20.11

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -5,7 +5,7 @@ mgmt_hostname: "{{ ansible_local.citc.mgmt_hostname }}"
 users: []
 
 # From https://www.schedmd.com/downloads.php
-slurm_version: 20.02
+slurm_version: 20.11
 
 slurm_cluster_name: cluster
 slurm_control_machine: "{{ mgmt_hostname }}"

--- a/group_vars/compute.yml
+++ b/group_vars/compute.yml
@@ -1,7 +1,7 @@
 ---
 slurm_packages:
   - slurmd
-  - libpmi
+  - pmi
 
 slurm_role: compute
 

--- a/group_vars/management.yml
+++ b/group_vars/management.yml
@@ -5,7 +5,7 @@ slurm_accounting_db_password: "{{ lookup('password', '/tmp/slurmpasswordfile cha
 slurm_packages:
   - slurmctld
   - slurmdbd
-  - libpmi
+  - pmi
 
 slurm_role: mgmt
 

--- a/roles/slurm/molecule/compute/molecule.yml
+++ b/roles/slurm/molecule/compute/molecule.yml
@@ -20,7 +20,7 @@ provisioner:
         slurm_packages:
           - slurmd
           - libpmi
-        slurm_version: 20.02
+        slurm_version: 20.11
         slurm_cluster_name: cluster
         slurm_control_machine: mgmt
         filesystem_mount_point: /shared

--- a/roles/slurm/molecule/mgmt/molecule.yml
+++ b/roles/slurm/molecule/mgmt/molecule.yml
@@ -21,7 +21,7 @@ provisioner:
           - slurmctld
           - slurmdbd
           - libpmi
-        slurm_version: 20.02
+        slurm_version: 20.11
         slurm_cluster_name: cluster
         slurm_control_machine: mgmt
         filesystem_mount_point: /shared

--- a/roles/slurm/tasks/main.yml
+++ b/roles/slurm/tasks/main.yml
@@ -1,4 +1,19 @@
 ---
+- name: check if powertools repo is already enabled
+  shell: |
+    set -o pipefail
+    dnf -q repolist --enabled powertools | grep -i powertools  # noqa 301
+  changed_when: false
+  register: powertools
+  failed_when: powertools.rc == 2
+  when: ansible_local.citc.csp != "oracle"
+
+- name: enable powertools module
+  command: dnf config-manager --set-enabled powertools
+  when:
+    - ansible_local.citc.csp != "oracle"
+    - powertools.rc != 0
+
 - name: install munge
   yum:
     name: munge
@@ -147,7 +162,7 @@
     dest: /etc/slurm/slurmdbd.conf
     owner: slurm
     group: slurm
-    mode: 0400
+    mode: 0600
   when: slurm_role == "mgmt"
   notify:
     - restart slurmdbd


### PR DESCRIPTION
- powertools repo needs enabling before Slurm installed
- Slurm pmi lib RPM name changed from slurm-libpmi to slurm-pmi
- Slurm DB conf file: change perms so startup validation checks pass

Hopefully addresses #107 