### PR TITLE
Build compute image from local Ansible playbook

### DIFF
--- a/compute.yml
+++ b/compute.yml
@@ -1,6 +1,7 @@
 ---
 
 - hosts: compute
+  become: yes
   tasks:
     - name: disable SELinux
       selinux:
@@ -8,6 +9,7 @@
         policy: targeted
 
 - hosts: compute
+  become: yes
   roles:
     - citc_user
     - filesystem

--- a/roles/packer/files/all.pkr.hcl
+++ b/roles/packer/files/all.pkr.hcl
@@ -23,11 +23,12 @@ variable "oracle_key_file" {}
 variable "destination_image_name" {}
 variable "cluster" {}
 variable "ca_cert" {}
+variable "ssh_username" {}
 
 source "googlecompute" "google" {
     account_file = var.google_account_file
     source_image_family = var.google_source_image_family
-    ssh_username = "centos"
+    ssh_username = var.ssh_username
     project_id = var.google_project_id
     zone = var.google_zone
     network = var.google_network
@@ -70,7 +71,7 @@ source "amazon-ebs" "aws" {
         owners = ["125523088429"]
         most_recent = true
     }
-    ssh_username = "centos"
+    ssh_username = var.ssh_username
     vpc_filter {
         filter {
             name = "tag:cluster"
@@ -104,7 +105,7 @@ source "oracle-oci" "oracle" {
     tags = {
         cluster = var.cluster
     }
-    ssh_username = "opc"
+    ssh_username = var.ssh_username
 }
 
 source "oracle-oci" "oracle-gpu" {
@@ -119,7 +120,7 @@ source "oracle-oci" "oracle-gpu" {
     tags = {
         cluster = var.cluster
     }
-    ssh_username = "opc"
+    ssh_username = var.ssh_username
 }
 
 build {
@@ -172,7 +173,7 @@ build {
     provisioner "ansible" {
         playbook_file = "/root/citc-ansible/compute.yml"
         groups = ["compute"]
-        user = "centos"
+        user = var.ssh_username
     }
 
     provisioner "shell" {

--- a/roles/packer/files/all.pkr.hcl
+++ b/roles/packer/files/all.pkr.hcl
@@ -165,8 +165,10 @@ build {
         ]
     }
 
-    provisioner "shell" {
-        script = "/etc/citc/packer/run_ansible.sh"
+    provisioner "ansible" {
+        playbook_file = "/root/citc-ansible/compute.yml"
+        groups = ["compute"]
+        user = "centos"
     }
 
     provisioner "shell" {

--- a/roles/packer/files/all.pkr.hcl
+++ b/roles/packer/files/all.pkr.hcl
@@ -165,6 +165,10 @@ build {
         ]
     }
 
+    provisioner "shell" {
+        script = "/etc/citc/packer/prepare_ansible.sh"
+    }
+
     provisioner "ansible" {
         playbook_file = "/root/citc-ansible/compute.yml"
         groups = ["compute"]

--- a/roles/packer/tasks/main.yml
+++ b/roles/packer/tasks/main.yml
@@ -49,10 +49,10 @@
   set_fact:
     startnode_config: "{{ startnode_config_data['content'] | b64decode | from_yaml }}"
 
-- name: copy in packer ansible run script
+- name: copy in packer ansible preparation script
   template:
-    src: run_ansible.sh.j2
-    dest: /etc/citc/packer/run_ansible.sh
+    src: prepare_ansible.sh.j2
+    dest: /etc/citc/packer/prepare_ansible.sh
     owner: root
     mode: u=rwx,g=,o=
 

--- a/roles/packer/tasks/main.yml
+++ b/roles/packer/tasks/main.yml
@@ -4,7 +4,7 @@
 
 - name: Download and unarchive Packer.
   unarchive:
-    src: https://releases.hashicorp.com/packer/1.7.0/packer_1.7.0_linux_amd64.zip
+    src: https://releases.hashicorp.com/packer/1.7.3/packer_1.7.3_linux_amd64.zip
     dest: /usr/local/bin
     remote_src: true
     creates: /usr/local/bin/packer

--- a/roles/packer/templates/prepare_ansible.sh.j2
+++ b/roles/packer/templates/prepare_ansible.sh.j2
@@ -27,4 +27,3 @@ EOF'
 sudo chmod u=rw,g=,o= /etc/ansible/facts.d/citc.fact
 sudo cat /etc/ansible/facts.d/citc.fact
 sudo mv /tmp/citc_authorized_keys /root/citc_authorized_keys
-sudo /usr/bin/ansible-pull --url={{ startnode_config.ansible_repo }} --checkout={{ startnode_config.ansible_branch }} --inventory=/tmp/hosts compute.yml

--- a/roles/packer/templates/variables.pkrvars.hcl.j2
+++ b/roles/packer/templates/variables.pkrvars.hcl.j2
@@ -1,7 +1,7 @@
 ca_cert = "{{ ca_cert }}"
 cluster = "{{ startnode_config.cluster_id }}"
 destination_image_name = "citc-slurm-compute"
-ssh_username = "{%- if ansible_local.citc.csp in ["aws", "google"] -%}{{ centos }}{%- else -%}{{ opc }}{%- endif -%}"
+ssh_username = "{%- if ansible_local.citc.csp in ["aws", "google"] -%}centos{%- else -%}opc{%- endif -%}"
 
 aws_arch = "x86_64"
 aws_region = "{%- if startnode_config.region is defined -%}{{ startnode_config.region }}{%- endif -%}"

--- a/roles/packer/templates/variables.pkrvars.hcl.j2
+++ b/roles/packer/templates/variables.pkrvars.hcl.j2
@@ -1,6 +1,7 @@
 ca_cert = "{{ ca_cert }}"
 cluster = "{{ startnode_config.cluster_id }}"
 destination_image_name = "citc-slurm-compute"
+ssh_username = "{%- if ansible_local.citc.csp in ["aws", "google"] -%}{{ centos }}{%- else -%}{{ opc }}{%- endif -%}"
 
 aws_arch = "x86_64"
 aws_region = "{%- if startnode_config.region is defined -%}{{ startnode_config.region }}{%- endif -%}"

--- a/roles/slurm/handlers/main.yml
+++ b/roles/slurm/handlers/main.yml
@@ -8,9 +8,3 @@
   service:
     name: slurmdbd
     state: restarted
-
-- name: restart slurmd
-  service:
-    name: slurmd
-    state: restarted
-  when: slurm_role == "compute" and packer_run is not defined

--- a/roles/slurm/tasks/main.yml
+++ b/roles/slurm/tasks/main.yml
@@ -120,8 +120,6 @@
     owner: slurm
     group: slurm
     mode: 0644
-  notify:
-    - restart slurmd
 
 - name: make slurm config directory
   file:
@@ -138,8 +136,6 @@
     group: slurm
     mode: 0644
   when: slurm_role == "mgmt"
-  notify:
-    - restart slurmd
 
 - name: slurmdbd config file
   template:
@@ -159,8 +155,6 @@
     owner: slurm
     group: slurm
     mode: 0400
-  notify:
-    - restart slurmd
 
 - name: set slurm log directory permissions
   file:
@@ -208,7 +202,6 @@
     state: enabled
   notify:
     - restart firewalld
-    - restart slurmd
 
 - include_tasks: elastic.yml
   when: slurm_role == "mgmt"
@@ -240,12 +233,6 @@
     name: slurmd
     enabled: yes
   when: slurm_role == "compute"
-
-- name: enable service slurmd
-  service:
-    name: slurmd
-    state: started
-  when: slurm_role == "compute" and packer_run is not defined
 
 # As of Slurm 18.08 the slurmdbd service doesn't become available immediately
 # This ensures that the service is available before continuing


### PR DESCRIPTION
Currently the image for the compute nodes is built, via packer, by invoking `ansible-pull`. This will always grab the latest version of the playbook from Git. We pin the branch to the same one as the management node was built from, but this requires care for compatibility on the branch.

This PR changes how Ansible is run by using Packer to to invoke `ansible-playbook` on the compute image which loads from the version of the playbook physically sitting on the management node. This ensures that they are always identical unless the admin explicitly updates them.