### PR TITLE
Install the telegraf package directly

### DIFF
--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -32,6 +32,8 @@
   notify: restart rsyslog
   when: monitoring_role != "master"
 
+# Currently only influxdb is in the aarch64 repo so we must use the arm64 repo. Once they
+# are in https://repos.influxdata.com/centos/8/aarch64/stable/ we can change.
 - name: Add InfluxDB repository
   yum_repository:
     name: influxdb
@@ -39,21 +41,10 @@
     baseurl: https://repos.influxdata.com/centos/$releasever/{{ "arm64" if ansible_architecture == "aarch64" else ansible_architecture }}/stable/
     gpgkey: https://repos.influxdata.com/influxdb.key
 
-# Due to https://github.com/influxdata/build-scripts/issues/6 we have to install the packages manually
-- name: download telegraf package
-  command:
-    cmd: dnf download telegraf --url
-  changed_when: False
-  register: telegraf_dnf
-
-- name: install telegraf package  # noqa 303
-  command:
-    cmd: "rpm -Uvh {{ telegraf_dnf.stdout_lines[-1] }} --ignorearch"
-  register: rpm_result
-  changed_when: '"Nothing to do" not in rpm_result.stdout and "is already installed" not in rpm_result.stderr'
-  failed_when:
-    - rpm_result.rc != 0
-    - '"is already installed" not in rpm_result.stderr'
+- name: install telegraf package
+  package:
+    name: telegraf
+    state: present
   notify: restart telegraf
 
 - name: enable the telegraf service


### PR DESCRIPTION
The [packaging bug with arm64](https://github.com/influxdata/build-scripts/issues/6) is now resolved by Influx so we can install the package in a normal way.