### PR TITLE
always install 'latest' version of EESSI CernVM-FS configuration

### DIFF
--- a/roles/packer/files/install_cvmfs_eessi.sh
+++ b/roles/packer/files/install_cvmfs_eessi.sh
@@ -30,8 +30,8 @@ else
     sudo dnf install -y cvmfs
 fi
 
-# install CernVM-FS configuration for EESSI
-sudo dnf install -y https://github.com/EESSI/filesystem-layer/releases/download/v0.2.3/cvmfs-config-eessi-0.2.3-1.noarch.rpm
+# install latest CernVM-FS configuration for EESSI
+sudo dnf install -y https://github.com/EESSI/filesystem-layer/releases/download/latest/cvmfs-config-eessi-latest.noarch.rpm
 
 # configure CernVM-FS (no proxy, 10GB quota for CernVM-FS cache)
 sudo bash -c "echo 'CVMFS_HTTP_PROXY=DIRECT' > /etc/cvmfs/default.local"


### PR DESCRIPTION
We switched from a using CernVM-FS configuration repository to a static configuration, so an update is required to get a working setup.

We now also have a `latest` tag, so it's probably better to always install this...