### PR TITLE
Rocky8 Linux AWS Compute Nodes

### DIFF
--- a/roles/packer/files/all.pkr.hcl
+++ b/roles/packer/files/all.pkr.hcl
@@ -63,10 +63,10 @@ source "amazon-ebs" "aws" {
     instance_type = var.aws_instance_type
     source_ami_filter {
         filters = {
-            name = "CentOS 8.*"
+            name = "Rocky-8*"
             architecture = var.aws_arch
         }
-        owners = ["125523088429"]
+        owners = ["792107900819"] #Owner ID as stated from https://forums.rockylinux.org/t/rocky-linux-official-aws-ami/3049/25
         most_recent = true
     }
     ssh_username = var.ssh_username

--- a/roles/packer/templates/prepare_ansible.sh.j2
+++ b/roles/packer/templates/prepare_ansible.sh.j2
@@ -9,9 +9,13 @@ $(hostname)
 cluster_id={{ startnode_config.cluster_id }}
 packer_run=yes
 EOF'
-{% if ansible_local.citc.csp in ["aws", "google"] %}
+{% if ansible_local.citc.csp == "google" %}
 sudo yum install -y epel-release
 sudo dnf config-manager --set-enabled powertools
+{% elif ansible_local.citc.csp == "aws" %}
+sudo yum install -y epel-release
+sudo dnf config-manager --set-enabled powertools
+sudo dnf install -y kernel-devel-$(uname -r) kernel-headers-$(uname -r)
 {% elif ansible_local.citc.csp == "oracle" %}
 sudo dnf install -y oracle-epel-release-el8
 sudo dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm

--- a/roles/packer/templates/variables.pkrvars.hcl.j2
+++ b/roles/packer/templates/variables.pkrvars.hcl.j2
@@ -5,7 +5,7 @@ ssh_username = "{%- if ansible_local.citc.csp in ["google"] -%}centos{%- elif an
 
 aws_arch = "x86_64"
 aws_region = "{%- if startnode_config.region is defined -%}{{ startnode_config.region }}{%- endif -%}"
-aws_instance_type = "t2.nano"
+aws_instance_type = "t2.micro"
 
 google_destination_image_family = "citc-slurm-compute"
 google_network = "{%- if startnode_config.network_name is defined -%}{{ startnode_config.network_name }}{%- endif -%}"

--- a/roles/packer/templates/variables.pkrvars.hcl.j2
+++ b/roles/packer/templates/variables.pkrvars.hcl.j2
@@ -1,7 +1,7 @@
 ca_cert = "{{ ca_cert }}"
 cluster = "{{ startnode_config.cluster_id }}"
 destination_image_name = "citc-slurm-compute"
-ssh_username = "{%- if ansible_local.citc.csp in ["aws", "google"] -%}centos{%- else -%}opc{%- endif -%}"
+ssh_username = "{%- if ansible_local.citc.csp in ["google"] -%}centos{%- elif ansible_local.citc.csp in ["aws"] -%}rocky{%- else -%}opc{%- endif -%}"
 
 aws_arch = "x86_64"
 aws_region = "{%- if startnode_config.region is defined -%}{{ startnode_config.region }}{%- endif -%}"


### PR DESCRIPTION
This pull request makes Rocky8 Linux the Source AMI for the compute nodes on AWS.

Associated issue: #121 

Changes include:
-  Changing the AMI to the community support Rocky8 as specified here: https://forums.rockylinux.org/t/rocky-linux-official-aws-ami/3049/25
- Changing the ssh name for compute nodes 
- Changing the AWS instance type to micro such that packer can run
- Adding kernel-devel and headers as the default install so the Nvidia driver can be installed properly following current documentation. 


After adding: 

```
if [[ $(arch) == "x86_64" ]]; then
  sudo dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
  sudo dnf module install -y nvidia-driver:latest-dkms
fi
```
as per the documentation and running `sudo /usr/local/bin/run-packer`

This is the resulting compute node output from 

```
#! /bin/bash

hostname
cat /etc/os-release
nvidia-smi -q | head
```

Output:

```adjusted-sunfish-g4dn-xlarge-0002
NAME="Rocky Linux"
VERSION="8.6 (Green Obsidian)"
ID="rocky"
ID_LIKE="rhel centos fedora"
VERSION_ID="8.6"
PLATFORM_ID="platform:el8"
PRETTY_NAME="Rocky Linux 8.6 (Green Obsidian)"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:rocky:rocky:8:GA"
HOME_URL="https://rockylinux.org/"
BUG_REPORT_URL="https://bugs.rockylinux.org/"
ROCKY_SUPPORT_PRODUCT="Rocky Linux"
ROCKY_SUPPORT_PRODUCT_VERSION="8"
REDHAT_SUPPORT_PRODUCT="Rocky Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="8"

==============NVSMI LOG==============

Timestamp                                 : Thu May 26 11:42:20 2022
Driver Version                            : 515.43.04
CUDA Version                              : 11.7

Attached GPUs                             : 1
GPU 00000000:00:1E.0
    Product Name                          : Tesla T4```

