### PR TITLE
Update Slurm Repo to fix openmpi

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -5,7 +5,7 @@ mgmt_hostname: "{{ ansible_local.citc.mgmt_hostname }}"
 users: []
 
 # From https://www.schedmd.com/downloads.php
-slurm_version: 20.02
+slurm_version: 20.11
 
 slurm_cluster_name: cluster
 slurm_control_machine: "{{ mgmt_hostname }}"

--- a/group_vars/compute.yml
+++ b/group_vars/compute.yml
@@ -1,7 +1,7 @@
 ---
 slurm_packages:
   - slurmd
-  - libpmi
+  - pmi
 
 slurm_role: compute
 

--- a/group_vars/compute.yml
+++ b/group_vars/compute.yml
@@ -14,7 +14,9 @@ mpi_packages:
   google:
     - mpich
     - openmpi
-  aws: []
+  aws:
+    - mpich
+    - openmpi
 
 monitoring_role: client
 

--- a/group_vars/management.yml
+++ b/group_vars/management.yml
@@ -5,7 +5,7 @@ slurm_accounting_db_password: "{{ lookup('password', '/tmp/slurmpasswordfile cha
 slurm_packages:
   - slurmctld
   - slurmdbd
-  - libpmi
+  - pmi
 
 slurm_role: mgmt
 

--- a/group_vars/management.yml
+++ b/group_vars/management.yml
@@ -27,7 +27,9 @@ mpi_packages:
   google:
     - openmpi-devel
     - mpich-devel
-  aws: []
+  aws:
+    - openmpi-devel
+    - mpich-devel
 
 monitoring_role: master
 grafana_admin_password: "{{ lookup('password', '/tmp/grafanapasswordfile chars=ascii_letters,digits,hexdigits') }}"

--- a/group_vars/management.yml
+++ b/group_vars/management.yml
@@ -15,7 +15,6 @@ slurm_elastic:
 
 install_packages:
   - xorg-x11-xauth
-  - openmpi-devel
   - python3-devel
   - "@Development Tools"
   - vim

--- a/roles/slurm/molecule/compute/molecule.yml
+++ b/roles/slurm/molecule/compute/molecule.yml
@@ -19,7 +19,7 @@ provisioner:
         slurm_role: compute
         slurm_packages:
           - slurmd
-          - libpmi
+          - pmi
         slurm_version: 20.02
         slurm_cluster_name: cluster
         slurm_control_machine: mgmt

--- a/roles/slurm/molecule/compute/molecule.yml
+++ b/roles/slurm/molecule/compute/molecule.yml
@@ -20,7 +20,7 @@ provisioner:
         slurm_packages:
           - slurmd
           - pmi
-        slurm_version: 20.02
+        slurm_version: 20.11
         slurm_cluster_name: cluster
         slurm_control_machine: mgmt
         filesystem_mount_point: /shared

--- a/roles/slurm/molecule/mgmt/molecule.yml
+++ b/roles/slurm/molecule/mgmt/molecule.yml
@@ -20,7 +20,7 @@ provisioner:
         slurm_packages:
           - slurmctld
           - slurmdbd
-          - libpmi
+          - pmi
         slurm_version: 20.02
         slurm_cluster_name: cluster
         slurm_control_machine: mgmt

--- a/roles/slurm/molecule/mgmt/molecule.yml
+++ b/roles/slurm/molecule/mgmt/molecule.yml
@@ -21,7 +21,7 @@ provisioner:
           - slurmctld
           - slurmdbd
           - pmi
-        slurm_version: 20.02
+        slurm_version: 20.11
         slurm_cluster_name: cluster
         slurm_control_machine: mgmt
         filesystem_mount_point: /shared

--- a/roles/slurm/tasks/main.yml
+++ b/roles/slurm/tasks/main.yml
@@ -64,14 +64,6 @@
     enabled: yes
     state: started
 
-- name: Add Slurm repository
-  yum_repository:
-    name: slurm
-    description: Slurm
-    baseurl: https://download.opensuse.org/repositories/home:/Milliams:/citc/EPEL_8_CentOS/
-    gpgcheck: yes
-    gpgkey: https://download.opensuse.org/repositories/home:/Milliams:/citc/EPEL_8_CentOS/repodata/repomd.xml.key
-
 - name: create slurm group
   group:
     name: slurm
@@ -143,7 +135,7 @@
     dest: /etc/slurm/slurmdbd.conf
     owner: slurm
     group: slurm
-    mode: 0400
+    mode: 0600
   when: slurm_role == "mgmt"
   notify:
     - restart slurmdbd


### PR DESCRIPTION
Openmpi didn't work with the slurm repo used as it caused openmpi not to install correctly leading to a pmix error. 

This pull request removes the need for an external repo for slurm and increases the slurm version number to 20.11. As well as unifying the openmpi and mpich installation, such that it is installed as default on AWS compute instances, like the other cloud providers. 