### PR TITLE
Ansible5 fixes

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -21,3 +21,5 @@ filesystem_mount_point: /shared
 software_install_dir: /mnt/{{ filesystem_mount_point }}
 
 admin_key_path: /root/citc_authorized_keys
+
+ansible_python_interpreter: /usr/libexec/platform-python

--- a/roles/monitoring/tasks/master.yml
+++ b/roles/monitoring/tasks/master.yml
@@ -101,7 +101,7 @@
     grafana_password: "{{ grafana_admin_password }}"
     name: influxdb_telegraf
     ds_type: influxdb
-    url: http://localhost:8086
+    ds_url: http://localhost:8086
     database: telegraf
   tags:
     - molecule-idempotence-notest  # https://github.com/ansible-collections/community.grafana/issues/127

--- a/roles/packer/files/all.pkr.hcl
+++ b/roles/packer/files/all.pkr.hcl
@@ -63,10 +63,10 @@ source "amazon-ebs" "aws" {
     instance_type = var.aws_instance_type
     source_ami_filter {
         filters = {
-            name = "CentOS 8.*"
+            name = "Rocky-8*"
             architecture = var.aws_arch
         }
-        owners = ["125523088429"]
+        owners = ["792107900819"] #Owner ID as stated from https://forums.rockylinux.org/t/rocky-linux-official-aws-ami/3049/25
         most_recent = true
     }
     ssh_username = var.ssh_username

--- a/roles/packer/templates/prepare_ansible.sh.j2
+++ b/roles/packer/templates/prepare_ansible.sh.j2
@@ -9,9 +9,13 @@ $(hostname)
 cluster_id={{ startnode_config.cluster_id }}
 packer_run=yes
 EOF'
-{% if ansible_local.citc.csp in ["aws", "google"] %}
+{% if ansible_local.citc.csp == "google" %}
 sudo yum install -y epel-release
 sudo dnf config-manager --set-enabled powertools
+{% elif ansible_local.citc.csp == "aws" %}
+sudo yum install -y epel-release
+sudo dnf config-manager --set-enabled powertools
+sudo dnf install -y kernel-devel-$(uname -r) kernel-headers-$(uname -r)
 {% elif ansible_local.citc.csp == "oracle" %}
 sudo dnf install -y oracle-epel-release-el8
 sudo dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm

--- a/roles/packer/templates/variables.pkrvars.hcl.j2
+++ b/roles/packer/templates/variables.pkrvars.hcl.j2
@@ -1,11 +1,11 @@
 ca_cert = "{{ ca_cert }}"
 cluster = "{{ startnode_config.cluster_id }}"
 destination_image_name = "citc-slurm-compute"
-ssh_username = "{%- if ansible_local.citc.csp in ["aws", "google"] -%}centos{%- else -%}opc{%- endif -%}"
+ssh_username = "{%- if ansible_local.citc.csp in ["google"] -%}centos{%- elif ansible_local.citc.csp in ["aws"] -%}rocky{%- else -%}opc{%- endif -%}"
 
 aws_arch = "x86_64"
 aws_region = "{%- if startnode_config.region is defined -%}{{ startnode_config.region }}{%- endif -%}"
-aws_instance_type = "t2.nano"
+aws_instance_type = "t2.micro"
 
 google_destination_image_family = "citc-slurm-compute"
 google_network = "{%- if startnode_config.network_name is defined -%}{{ startnode_config.network_name }}{%- endif -%}"

--- a/roles/webui/tasks/main.yml
+++ b/roles/webui/tasks/main.yml
@@ -96,7 +96,7 @@
 
 - name: checkout webui
   git:
-    repo: git://github.com/clusterinthecloud/webui.git
+    repo: https://github.com/clusterinthecloud/webui.git
     force: yes
     dest: "{{ webui_dir }}"
     version: master


### PR DESCRIPTION
Epel has now released version 5.4 of Ansible within stable with this there are a few things that broke these are the fixes.

- Selinux commands
   -  Ansible no longer defaults to platform-python which is python3.6 which allows the python36-libselinux package to be used, instead it uses python3.8 and therefore the libselinux package cannot be used due to being a different version.  The fix was to set the ansible python interpreter to platform-python as this defaults to python3.6 and is the recommended solution: https://bugzilla.redhat.com/show_bug.cgi?id=2091684
- grafana_datasource module
  -  The fix was to change `url`  to `ds_url` as due to this version update `url` no longer aliases to `ds_url` and now is an alias to `grafana_url`, therefore making the `url` explicit with `ds_url` fixed this problem. An overview of the new format can be found here: https://docs.ansible.com/ansible/5/collections/community/grafana/grafana_datasource_module.html.