### PR TITLE
Ansible update fixes

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -21,3 +21,5 @@ filesystem_mount_point: /shared
 software_install_dir: /mnt/{{ filesystem_mount_point }}
 
 admin_key_path: /root/citc_authorized_keys
+
+ansible_python_interpreter: /usr/libexec/platform-python

--- a/roles/monitoring/tasks/master.yml
+++ b/roles/monitoring/tasks/master.yml
@@ -101,7 +101,7 @@
     grafana_password: "{{ grafana_admin_password }}"
     name: influxdb_telegraf
     ds_type: influxdb
-    url: http://localhost:8086
+    ds_url: http://localhost:8086
     database: telegraf
   tags:
     - molecule-idempotence-notest  # https://github.com/ansible-collections/community.grafana/issues/127


### PR DESCRIPTION
Epel has now released version 5.4 of Ansible within stable with this there are a few things that broke these are the fixes.

- Selinux commands
  - Ansible no longer defaults to platform-python which is python3.6 which allows the python36-libselinux package to be used, instead it uses python3.8 and therefore the libselinux package cannot be used due to being a different version. The fix was to set the ansible python interpreter to platform-python as this defaults to python3.6 and is the recommended solution: https://bugzilla.redhat.com/show_bug.cgi?id=2091684
- grafana_datasource module
  - The fix was to change url to ds_url as due to this version update url no longer aliases to ds_url and now is an alias to grafana_url, therefore making the url explicit with ds_url fixed this problem. An overview of the new format can be found here: https://docs.ansible.com/ansible/5/collections/community/grafana/grafana_datasource_module.html.