### PR TITLE
Ceph distrac support

### DIFF
--- a/compute.yml
+++ b/compute.yml
@@ -22,3 +22,4 @@
     - mpi
     - slurm
     - monitoring
+    - ceph

--- a/compute.yml
+++ b/compute.yml
@@ -23,3 +23,5 @@
     - slurm
     - monitoring
     - ceph
+    - distrac
+    - distrac_group

--- a/group_vars/compute.yml
+++ b/group_vars/compute.yml
@@ -16,6 +16,18 @@ mpi_packages:
     - openmpi
   aws: []
 
+ceph_packages:
+  - ceph
+  - ceph-base
+  - ceph-common
+  - ceph-osd
+  - ceph-mon
+  - ceph-mgr
+  - ceph-mds
+  - ceph-radosgw
+  - ceph-volume
+  - lvm2
+
 monitoring_role: client
 
 ldap_hostname: "{{ ansible_local.citc.ldap_hostname }}"

--- a/group_vars/compute.yml
+++ b/group_vars/compute.yml
@@ -28,6 +28,8 @@ ceph_packages:
   - ceph-volume
   - lvm2
 
+ceph_version: quincy
+
 monitoring_role: client
 
 ldap_hostname: "{{ ansible_local.citc.ldap_hostname }}"

--- a/management.yml
+++ b/management.yml
@@ -45,6 +45,7 @@
     - security_updates
     - ntp
     - sssd
+    - distrac_group
     - users
   tasks:
     - name: copy SSH public keys to slurm account

--- a/roles/ceph/tasks/main.yaml
+++ b/roles/ceph/tasks/main.yaml
@@ -1,0 +1,37 @@
+---
+
+- name: Add Ceph {{ ansible_architecture }} repository
+  yum_repository:
+    name: ceph
+    description: Ceph packages for {{ ansible_architecture }}
+    baseurl: https://download.ceph.com/rpm-{{ ceph_version }}/el$releasever/{{ ansible_architecture }}
+    enabled: 1
+    priority: 2
+    gpgcheck: 1
+    gpgkey: https://download.ceph.com/keys/release.asc
+
+- name: Add Ceph noarch repository
+  yum_repository:
+    name: ceph-noarch
+    description: Ceph noarch packages
+    baseurl: https://download.ceph.com/rpm-{{ ceph_version }}/el$releasever/noarch
+    enabled: 1
+    priority: 2
+    gpgcheck: 1
+    gpgkey: https://download.ceph.com/keys/release.asc
+
+- name: Add Ceph source repository
+  yum_repository:
+    name: ceph-source
+    description: Ceph noarch packages
+    baseurl: https://download.ceph.com/rpm-{{ ceph_version }}/el$releasever/SRPMS
+    enabled: 1
+    priority: 2
+    gpgcheck: 1
+    gpgkey: https://download.ceph.com/keys/release.asc
+
+- name: install ceph
+  package:
+    name: '{{ item }}'
+    state: present
+  loop:  "{{ ceph_packages }}"

--- a/roles/distrac/defaults/main.yaml
+++ b/roles/distrac/defaults/main.yaml
@@ -1,0 +1,2 @@
+---
+distrac_src_dir: "/usr/local/src/distrac"

--- a/roles/distrac/tasks/main.yaml
+++ b/roles/distrac/tasks/main.yaml
@@ -1,0 +1,39 @@
+---
+
+- name: ensure git is installed
+  package:
+    name: git
+
+- name: checkout DisTRaC
+  git:
+    repo: https://github.com/rosalindfranklininstitute/distrac.git
+    force: yes
+    dest: "{{ distrac_src_dir }}"
+    version: master
+
+- name: copy in sudoers files
+  copy:
+    remote_src: true
+    src: "{{ distrac_src_dir }}/sudoers_file/distrac"
+    dest: /etc/sudoers.d/distrac
+    mode: u=r,g=r
+    validate: /usr/sbin/visudo -csf %s
+
+- name: get distrac files
+  find:
+    paths: "{{ distrac_src_dir }}/distrac"
+    patterns: '*.sh'
+  register: distrac_src
+
+- name: copy distrac to bin
+  copy:
+    remote_src: true
+    src: "{{ item.path }}"
+    dest: /usr/bin
+    mode: u=rwx,g=rx,o=rx
+  loop: "{{ distrac_src.files }}"
+
+- name: install bc
+  package:
+    name: "bc"
+    state: present

--- a/roles/distrac_group/files/add_user_to_distrac_group.sh
+++ b/roles/distrac_group/files/add_user_to_distrac_group.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+if [[ $# -ne 1 ]]; then
+    echo "Call with:"
+    echo "    ${0} <user name>"
+    exit 1
+fi
+
+USER=${1}
+usermod -a -G distrac ${USER}

--- a/roles/distrac_group/tasks/main.yaml
+++ b/roles/distrac_group/tasks/main.yaml
@@ -1,0 +1,14 @@
+---
+
+- name: Ensure group distrac group exists
+  group:
+    name: distrac
+    gid: 2000
+    state: present
+
+- name: create add user to distrac group script
+  copy:
+    src: add_user_to_distrac_group.sh
+    dest: /usr/local/libexec/add_user_to_distrac_group
+    mode: go=r,u=rwx
+  register: add_user_to_distrac_group

--- a/roles/users/templates/add_user_ldap.j2
+++ b/roles/users/templates/add_user_ldap.j2
@@ -60,3 +60,5 @@ EOF
 curl --silent ${SSHKEYS} | /usr/local/libexec/set_ssh_key ${USER}
 
 echo "${PASSWORD}" | /usr/local/libexec/set_password_file ${USER}
+
+/usr/local/libexec/add_user_to_distrac_group ${USER}


### PR DESCRIPTION
This pull request adds support for Ceph and DisTRaC.

This is done with the creation of 3 roles

- Ceph:
   -  This sets up the repos and installs the Quincy(latest as of writing) version of ceph on the compute nodes.
- DisTRaC:
   - This clones the DisTRaC repo down and installs it into `/usr/bin` on the compute nodes.
- DisTRaC Group:
   - This creates the DisTRaC group with GID 2000 and copies the script to add a user to the group into `/usr/local/libexec/` and the ldap_create user is modified to run the add_user_to_distrac_group
   -  The reason this was separated into a separate role is that it stays constant with the current ansible method of limited tag usage and helps remove code duplication that would otherwise be required to modify the users and distrac roles. Looking forward it may be worth adding tagging (i.e compute, management) such that this doesn't need to be in a separate role.
   