### PR TITLE
Don't validate the GPG key of the influxdb repo

### DIFF
--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -18,7 +18,7 @@
     name: influxdb
     description: InfluxDB
     baseurl: https://repos.influxdata.com/centos/$releasever/{{ "arm64" if ansible_architecture == "aarch64" else ansible_architecture }}/stable/
-    gpgkey: https://repos.influxdata.com/influxdb.key
+    gpgcheck: false
 
 - name: install telegraf package
   package:


### PR DESCRIPTION
The packages are no longer signed, so the check fails.