### PR TITLE
Update the version of Ansible

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install 'ansible<2.10,>=2.9' 'ansible-lint<6.0.0'
+          pip install 'ansible ~= 8.0' 'ansible-lint'
       - name: Ansible lint
         run: |
           ansible-lint --offline management.yml compute.yml nfsserver.yml
@@ -63,7 +63,7 @@ jobs:
         run: sudo apt-get install python3-docker
       - name: Install Molecule
         run: |
-          python -m pip install 'ansible<2.10,>=2.9' 'ansible-lint<6.0.0' 'molecule[podman,docker]==3.4.1'
+          python -m pip install 'ansible ~= 8.0' 'ansible-lint' 'molecule[podman,docker]'
       - name: Test role
         run: |
           cd roles/${{ matrix.role }}

--- a/management.yml
+++ b/management.yml
@@ -4,9 +4,9 @@
   hosts: management
   tasks:
     - name: Download required roles
-      command: ansible-galaxy install -r requirements.yml
-      register: galaxy_result
-      changed_when: '"was installed successfully" in galaxy_result.stdout'
+      community.general.ansible_galaxy_install:
+        type: both
+        requirements_file: requirements.yml
       become: false
       delegate_to: localhost
 

--- a/roles/ldap/tasks/main.yml
+++ b/roles/ldap/tasks/main.yml
@@ -37,6 +37,10 @@
     host: "{{ mgmt_hostname }}"
     port: 389
 
+- name: Install Python LDAP
+  package:
+    name: python3-ldap
+
 - name: ensure people OU exists
   ldap_entry:
     dn: ou=People,dc=citc,dc=acrc,dc=bristol,dc=ac,dc=uk

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+
 - name: install PyMySQL
   package:
     name: python3-PyMySQL

--- a/roles/packer/files/all.pkr.hcl
+++ b/roles/packer/files/all.pkr.hcl
@@ -153,6 +153,7 @@ build {
     }
 
     provisioner "ansible" {
+        command = "/etc/citc/packer/run-ansible.sh"
         playbook_file = "/root/citc-ansible/compute.yml"
         groups = ["compute"]
         user = var.ssh_username

--- a/roles/packer/tasks/main.yml
+++ b/roles/packer/tasks/main.yml
@@ -56,6 +56,13 @@
     owner: root
     mode: u=rwx,g=,o=
 
+- name: copy in packer ansible wrapper script
+  template:
+    src: run-ansible.sh.j2
+    dest: /etc/citc/packer/run-ansible.sh
+    owner: root
+    mode: "u=rwx,g=,o="
+
 - name: copy in packer extra run script template (no force overwrite)
   copy:
     src: compute_image_extra.sh

--- a/roles/packer/tasks/main.yml
+++ b/roles/packer/tasks/main.yml
@@ -93,7 +93,7 @@
     mode: u=rwx,g=rx,o=rx
 
 # Ansible will not wait for this task until it gets to the `finalise` role
-- name: run packer to build first image
+- name: run packer to build first image (runs in background)
   command: /usr/local/bin/run-packer  # noqa no-changed-when
   register: packer_result
   async: 1000

--- a/roles/packer/templates/prepare_ansible.sh.j2
+++ b/roles/packer/templates/prepare_ansible.sh.j2
@@ -1,14 +1,8 @@
 #! /bin/bash
 set -euo pipefail
 
-echo 'packer' | sudo -S sh -c '
-cat > /tmp/hosts <<EOF
-[compute]
-$(hostname)
-[all:vars]
-cluster_id={{ startnode_config.cluster_id }}
-packer_run=yes
-EOF'
+# This script runs on the packer node to set things up, ready to have Ansible connect to it.
+
 {% if ansible_local.citc.csp == "google" %}
 sudo yum install -y epel-release
 sudo dnf config-manager --set-enabled powertools
@@ -21,13 +15,10 @@ sudo dnf install -y oracle-epel-release-el8
 sudo dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 sudo dnf config-manager --set-enabled ol8_codeready_builder
 {% endif %}
-sudo dnf install -y ansible git
-sudo cat /tmp/hosts
 sudo mkdir -p /etc/ansible/facts.d/
 echo 'packer' | sudo -S sh -c '
 cat > /etc/ansible/facts.d/citc.fact <<EOF
 {"csp":"{{ ansible_local.citc.csp }}", "fileserver_ip":"{{ ansible_local.citc.fileserver_ip }}", "mgmt_hostname":"{{ mgmt_hostname }}", "ldap_hostname":"{{ ldap_hostname }}", "ldap_dm_password":"{{ ldap_dm_password }}" }
 EOF'
 sudo chmod u=rw,g=,o= /etc/ansible/facts.d/citc.fact
-sudo cat /etc/ansible/facts.d/citc.fact
 sudo mv /tmp/citc_authorized_keys /root/citc_authorized_keys

--- a/roles/packer/templates/run-ansible.sh.j2
+++ b/roles/packer/templates/run-ansible.sh.j2
@@ -1,0 +1,6 @@
+#!/bin/bash
+# This script runs on the mgmt node and connects to the remote packer node
+# The virtual environment being sourced is referring to the one on the mgmt node
+# If ANSIBLE_PYTHON_INTERPRETER is set, it is referring to the one on the packer node
+source /opt/venvs/ansible/bin/activate
+ansible-playbook "$@"


### PR DESCRIPTION
The version of Ansible installed by CitC is being updated in clusterinthecloud/terraform#74

The root reason for this is that since Ansible is being sourced from EPEL, it is linking against Python 3.11 which does not include various system Pytohn modules (e.g. firewalld and selinux). This updates the Ansible code to use this new installation when provisioning the compute node images as well as ensuring that the correct modules are installed in the system Python.