### PR TITLE
Upgrade to python-citc 0.3.11

### DIFF
--- a/roles/slurm/molecule/mgmt/prepare.yml
+++ b/roles/slurm/molecule/mgmt/prepare.yml
@@ -37,7 +37,9 @@
         mode: a=rw,o+x
     - name: create local citc.fact file  # Put there by Terraform usually
       copy:
+        # Choose one CSP for now, based on Python package installation speed
+        # TODO parameterise on CSP
         content: |
-          {"csp":"example", "fileserver_ip":"10.0.0.1", "mgmt_hostname":"mgmt"}
+          {"csp":"google", "fileserver_ip":"10.0.0.1", "mgmt_hostname":"mgmt"}
         dest: /etc/ansible/facts.d/citc.fact
         mode: u=rw,g=r,o=r

--- a/roles/slurm/tasks/elastic.yml
+++ b/roles/slurm/tasks/elastic.yml
@@ -2,8 +2,7 @@
 - name: Install common tools
   ansible.builtin.pip:
     name:
-      - PyYAML
-      - https://github.com/clusterinthecloud/python-citc/releases/download/0.3.10/citc-0.3.10-py3-none-any.whl
+      - citc[{{ ansible_local.citc.csp }}] @ https://github.com/clusterinthecloud/python-citc/releases/download/0.3.11/citc-0.3.11-py3-none-any.whl
     virtualenv: /opt/cloud_sdk
     virtualenv_command: "{{ python_venv }}"
   register: cloud_sdk_venv


### PR DESCRIPTION
This allows us to only install the Python dependencies for the cloud service that we're running on, slightly speeding up (by around 30 seconds) the deployment of the management node.