### PR TITLE
Install Slurm packages in one go

### DIFF
--- a/roles/slurm/tasks/main.yml
+++ b/roles/slurm/tasks/main.yml
@@ -88,10 +88,14 @@
     uid: 245
 
 - name: Install Slurm
-  ansible.builtin.yum:
-    name: slurm-{{ item }}-{{ slurm_version }}*
+  ansible.builtin.package:
+    name: "{{ slurm_packages | map('regex_replace', '^(.*)$', slurm_package_template) | list }}"
     state: present
-  loop: "{{ slurm_packages }}"
+  vars:
+    slurm_package_template: "slurm-\\1-{{ slurm_version }}*"  # The \1 will be replaced by the package name ↑
+  register: slurm_installed
+  until: slurm_installed is not failed
+  retries: 5
 
 - name: Create slurm accounting database
   community.mysql.mysql_db:


### PR DESCRIPTION
Instead of looping in Ansible to install each of the Slurm packages, install them by providing a list of names. This will hopefully make the installation faster (about 5 seconds) and more resilient.

This also adds a retry loop to the installation to hopefully avoid it falling over with GPG errors.