### PR TITLE
OpenStack: Set security group for Packer image build instance

### DIFF
--- a/roles/packer/files/all.pkr.hcl
+++ b/roles/packer/files/all.pkr.hcl
@@ -20,6 +20,7 @@ variable "oracle_key_file" {}
 
 variable "openstack_network" {}
 variable "openstack_ceph_network" {}
+variable "openstack_security_group" {}
 
 variable "destination_image_name" {}
 variable "cluster" {}
@@ -117,6 +118,7 @@ source "openstack" "openstack" {
     source_image_name = "Rocky-8.8"
     ssh_username = var.ssh_username
     networks = [var.openstack_network, var.openstack_ceph_network]
+    security_groups = [var.openstack_security_group]
     image_tags = ["compute"]
     metadata = {"cluster": var.cluster}
 }

--- a/roles/packer/templates/variables.pkrvars.hcl.j2
+++ b/roles/packer/templates/variables.pkrvars.hcl.j2
@@ -25,3 +25,4 @@ oracle_key_file = "/home/slurm/.oci/oci_api_key.pem"
 
 openstack_network = "{%- if startnode_config.network_id is defined -%}{{ startnode_config.network_id }}{%- endif -%}"
 openstack_ceph_network = "{%- if startnode_config.ceph_network is defined -%}{{ startnode_config.ceph_network }}{%- endif -%}"
+openstack_security_group = "{%- if startnode_config.security_group is defined -%}{{ startnode_config.security_group }}{%- endif -%}"

--- a/roles/sssd/tasks/main.yml
+++ b/roles/sssd/tasks/main.yml
@@ -16,6 +16,11 @@
 - name: Update CA trust anchors
   ansible.builtin.command: update-ca-trust  # noqa no-changed-when
 
+- name: Install authselect
+  ansible.builtin.package:
+    name: authselect
+    state: present
+
 - name: Enable SSSD auth in PAM
   ansible.builtin.command: authselect select sssd --force  # noqa no-changed-when
 


### PR DESCRIPTION
Use security group from startnode configuration.

This should avoid the Packer image build instance from using the project's default security group (fixes #147).

Also:

* Explicitly install `authselect` package when running sssd role's tasks
  * In some Rocky 8 images, it seems that `authselect` is not present and needs to be installed prior to running the "Enable SSSD auth in PAM" task 